### PR TITLE
Fix leaks

### DIFF
--- a/Examples/SpriteGame/Sources/SpriteGame/Explosion.swift
+++ b/Examples/SpriteGame/Sources/SpriteGame/Explosion.swift
@@ -7,7 +7,7 @@ public enum Explosion {
 
         sprite.setUpdateFunction(update)
 
-        sprite.setImage(loadImage(0))
+        sprite.setImage(loadImage(1))
 
         sprite.moveTo(x: x, y: y)
 
@@ -21,7 +21,7 @@ public enum Explosion {
     private static func update(sprite: Sprite) {
         let frameNumber = sprite.tag + 1
 
-        if frameNumber > 7 {
+        if frameNumber > 8 {
             Sprite.remove(sprite)
         }
         else {

--- a/swift-pd/Sources/Playdate/Graphics.swift
+++ b/swift-pd/Sources/Playdate/Graphics.swift
@@ -23,15 +23,17 @@ public enum Graphics {
     }
 
     public class Bitmap {
-        let c_bitmap: OpaquePointer?
+        let c_bitmap: OpaquePointer
 
-        public init(x: Int, y: Int, bgColor: Color) {
-            c_bitmap = c_gfx.newBitmap(Int32(x), Int32(y), bgColor.rawValue)
+        public init(x: Int, y: Int, bgColor: Color) throws {
+            let ptr = c_gfx.newBitmap(Int32(x), Int32(y), bgColor.rawValue)
+            c_bitmap = try checkResult(ptr, nil)
         }
 
         public init(path: String) throws {
             var err: UnsafePointer<CChar>? = nil
-            c_bitmap = c_gfx.loadBitmap(path, &err)
+            let ptr = c_gfx.loadBitmap(path, &err)
+            c_bitmap = try checkResult(ptr, err)
         }
 
         public var width: Int {
@@ -58,18 +60,18 @@ public enum Graphics {
     }
 
     public class Font {
-        var c_font: OpaquePointer?
+        var c_font: OpaquePointer
 
         public init(path: String) throws {
             var err: UnsafePointer<CChar>? = nil
-            c_font = c_gfx.loadFont(path, &err)
-            try checkError(err)
+            let ptr = c_gfx.loadFont(path, &err)
+            c_font = try checkResult(ptr, err)
         }
 
-        // TODO: do Fonts need to be freed? it's unclear from the docs
-        // deinit {
-
-        // }
+        deinit {
+            // There's no API to free Font instances; this seems to eliminate any leakage:
+            let _ = System.realloc(ptr: UnsafeMutableRawPointer(c_font), size: 0)
+        }
     }
 
 

--- a/swift-pd/Sources/Playdate/Playdate.swift
+++ b/swift-pd/Sources/Playdate/Playdate.swift
@@ -1,14 +1,27 @@
 import CPlaydate
 
-public enum RuntimeError: Error {
-    case msg(String)
-}
-
 /// Just a namespace to hold onto the single global reference to the C API struct.
 enum Playdate {
     static var c_api: PlaydateAPI!
 }
 
+public enum RuntimeError: Error {
+    case msg(String)
+    case allocNull
+}
+
+/// If an error message is produced, or the ptr is nil, throw a RuntimeError.
+func checkResult(_ ptr: OpaquePointer?, _ err: UnsafePointer<CChar>?) throws -> OpaquePointer {
+    if let err = err {
+        throw RuntimeError.msg(String(cString: err))
+    }
+    else if let nonNilPtr = ptr {
+        return nonNilPtr
+    }
+    else {
+        throw RuntimeError.allocNull
+    }
+}
 func checkError(_ err: UnsafePointer<CChar>?) throws {
     if let err = err {
         throw RuntimeError.msg(String(cString: err))

--- a/swift-pd/Sources/Playdate/Sprite.swift
+++ b/swift-pd/Sources/Playdate/Sprite.swift
@@ -84,11 +84,14 @@ public class Sprite {
         // Worse, if someone else still has a reference to the (Swift) Bitmap and tries to
         // use it, is it already freed underneath?
         // At a minimum, maybe need to release the old image when a new one arrives?
-        let _ = Unmanaged.passRetained(image)
+        // let _ = Unmanaged.passRetained(image)
 
-        Sprite.c_sprite.setImage(c_ptr, image.c_bitmap, LCDBitmapFlip(flip.rawValue))
+        // Retain a reference to the old image until after the (C) Sprite no longer refers to it:
+        withExtendedLifetime(self.image) {
+            self.image = image
 
-        self.image = image
+            Sprite.c_sprite.setImage(c_ptr, image.c_bitmap, LCDBitmapFlip(flip.rawValue))
+        }
     }
 
     /// Might as well expose this, since we're holding onto it in order to keep it from being

--- a/swift-pd/Sources/Playdate/Sprite.swift
+++ b/swift-pd/Sources/Playdate/Sprite.swift
@@ -71,21 +71,7 @@ public class Sprite {
         Sprite.c_sprite.moveBy(c_ptr, dx, dy)
     }
 
-    /// Warning: once a Bitmap has been associated with a Sprite, it might or might not be safe to
-    /// use the Bitmap elsewhere. More research is needed.
     public func setImage(_ image: Graphics.Bitmap, flip: Flip = .unflipped) {
-        // Tricky: it looks like the C sprite takes ownership of the bitmap, and will free it when
-        // necessary (e.g when the sprite itself is freed or when a new image is set.) But our
-        // Swift wrapper is also going to free the Bitmap as soon as the reference here is
-        // pointed to a new object. Therefore we do some hackish manual refcount updating.
-        // This is probably not the approved technique.
-        // At best, this is leaking the (Swift) Bitmap instance that's still holding onto a
-        // pointer to the (C) Bitmap that will eventually be freed out from under it.
-        // Worse, if someone else still has a reference to the (Swift) Bitmap and tries to
-        // use it, is it already freed underneath?
-        // At a minimum, maybe need to release the old image when a new one arrives?
-        // let _ = Unmanaged.passRetained(image)
-
         // Retain a reference to the old image until after the (C) Sprite no longer refers to it:
         withExtendedLifetime(self.image) {
             self.image = image


### PR DESCRIPTION
Turns out you do need to free Font instances, and you can do that with `realloc(font, 0)`. That was worth 5KB on every frame.

There was a bug in SpriteGame where it would try load `explosion/0`, which doesn't exist. That would lead to a null pointer being freed, but only later on, since I had disabled garbage collection for bitmaps used with sprites, thinking the issue was more subtle.

In addition to fixing that, now throwing a RuntimeError immediately if any bitmap or font load produces null.

With those two fixes, SpriteGame now runs for a long time in 100 KB.